### PR TITLE
[Fix] - DOS/UNIX Line Endings Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM tutum/apache-php
 
 # Install mysql-client
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y mysql-client unzip
+RUN apt-get install -y mysql-client unzip dos2unix
+ENV TERM xterm
 
 # Install wp-cli
 ADD https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp
@@ -18,6 +19,7 @@ RUN chown -R www-data:www-data /app/wp-content /var/www/html
 RUN mkdir -p /scripts
 ADD ./scripts/setup-wordpress.sh /scripts/setup-wordpress.sh
 RUN chmod 755 /scripts/*.sh
+RUN dos2unix -q /scripts/setup-wordpress.sh /scripts/setup-wordpress.sh
 RUN /scripts/setup-wordpress.sh
 
 # Configure Apache
@@ -30,6 +32,7 @@ ADD ./scripts/restore-db.sh /scripts/restore-db.sh
 ADD ./scripts/install-plugins.sh /scripts/install-plugins.sh
 ADD ./scripts/remove-plugins.sh /scripts/remove-plugins.sh
 RUN chmod 755 /scripts/*.sh
+RUN find /scripts -type f -exec dos2unix -q {} \;
 
 # Run the server
 EXPOSE 80 443


### PR DESCRIPTION
- For some users (tested on Windows) the Dockerfile would not run to completion
due to DOS line endings in the .sh files confusing UNIX VMs. This commit adds the
dos2unix package and converts the files on the fly during the build of the
Dockerfile.
- Secondarily, this PR also adds `TERM=xterm` to the build environment to prevent the myriad error messages (see below) that occur without it being explicitly set (at least on windows machines running Docker Toolbox).
- Fixes visiblevc/wordpress-starter#4

```sh
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
```