### PR TITLE
Stop apache complaining about existing pid file

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -13,4 +13,6 @@ else
 fi
 
 source /etc/apache2/envvars
+# stops apache complaining about existing pid file
+rm -f $APACHE_PID_FILE
 exec apache2 -D FOREGROUND


### PR DESCRIPTION
wordpress_1 | httpd (pid 1) already running
theproject_wordpress_1 exited with code 0

Silently remove pid file if exists or not.