### PR TITLE
Fix apache issue causing build crashes on restart

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -186,5 +186,7 @@ printf "\t%s\n" \
 
 # Start apache
 # ------------
+
+rm -f /var/run/apache2/apache2.pid
 source /etc/apache2/envvars
 exec apache2 -D FOREGROUND


### PR DESCRIPTION
Apache is fussy about starting if a pid already exists in the `/var/run/apache2` directory. This change removes that file so that it won't crash with the following error message:

```sh
httpd (pid1) already running
```