### PR TITLE
Add quotes to docker-compose.yml boolean in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ services:
         academic-bloggers-toolkit,
         co-authors-plus
       SEARCH_REPLACE: yoursite.com,localhost:8080
-      WP_DEBUG: true
+      WP_DEBUG: 'true'
   db:
     image: mysql:5.7
     ports:


### PR DESCRIPTION
Added quotes around `WP_DEBUG` boolean value in the example `docker-compose.yml` in the readme.

Without quotes, adding `WP_DEBUG: true` returns this error:

```
ERROR: Validation failed in file './docker-compose.yml', reason(s):
services.wordpress.environment.WP_DEBUG contains true, which is an invalid type,
it should be a string, number, or a null
```

Per [Docker compose file reference](https://docs.docker.com/compose/compose-file/#environment):

> Any boolean values; true, false, yes no, need to be enclosed in quotes to ensure they are not converted to True or False by the YML parser.