### PR TITLE
Add Support for Configuration of Database Hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository does 2 things:
 
 If you don't plan to build the Docker image yourself, you shouldn't care for 1. We publish the image on Docker Hub and you can grab it directly from there. That's why you can safely remove the Dockerfile and run.sh.
 
-The reason we remove `.git`, `REAMDE.md` and `CHANGELOG.md` is because we assume you will start your own repository, named after your project. There is virtually no benefit keeping ties with our remote git repository.
+The reason we remove `.git`, `README.md` and `CHANGELOG.md` is because we assume you will start your own repository, named after your project. There is virtually no benefit keeping ties with our remote git repository.
 
 ---
 
@@ -62,6 +62,7 @@ services:
       - ./yourplugin:/app/wp-content/plugins/yourplugin # Plugin development
       - ./yourtheme:/app/wp-content/themes/yourtheme   # Theme development
     environment:
+      DB_HOST: db
       DB_NAME: wordpress
       DB_PASS: root # must match below
       PLUGINS: >-
@@ -83,6 +84,7 @@ volumes:
 
 ##### MySQL Credentials
 
+- hostname: `db` (can be changed with the `DB_HOST` environment variable)
 - username: `root`
 - password: `root` (can be changed with the `MYSQL_ROOT_PASSWORD` and `DB_PASS` environment variables)
 - database: `wordpress` (can be changed with the `DB_NAME` environment variable)
@@ -90,6 +92,7 @@ volumes:
 
 ##### WordPress Container Environment variables
 
+- `DB_HOST` (optional): Defaults to `db`
 - `DB_PASS` (required): Must match `MYSQL_ROOT_PASSWORD` of the mysql container
 - `DB_NAME` (optional): Defaults to `wordpress`
 - `DB_PREFIX` (optional): Defauts to `wp_`

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-ADMIN_EMAIL=${ADMIN_EMAIL:-"admin@${DB_NAME}.com"}
 DB_HOST=${DB_HOST:-'db'}
 DB_NAME=${DB_NAME:-'wordpress'}
 DB_PASS=${DB_PASS:-'root'}
 DB_PREFIX=${DB_PREFIX:-'wp_'}
+ADMIN_EMAIL=${ADMIN_EMAIL:-"admin@${DB_NAME}.com"}
 THEMES=${THEMES:-'twentysixteen'}
 WP_DEBUG_DISPLAY=${WP_DEBUG_DISPLAY:-'true'}
 WP_DEBUG_LOG=${WB_DEBUG_LOG:-'false'}

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ADMIN_EMAIL=${ADMIN_EMAIL:-"admin@${DB_NAME}.com"}
+DB_HOST=${DB_HOST:-'db'}
 DB_NAME=${DB_NAME:-'wordpress'}
 DB_PASS=${DB_PASS:-'root'}
 DB_PREFIX=${DB_PREFIX:-'wp_'}
@@ -30,7 +31,7 @@ core config:
   dbpass: $DB_PASS
   dbname: $DB_NAME
   dbprefix: $DB_PREFIX
-  dbhost: db:3306
+  dbhost: $DB_HOST:3306
   extra-php: |
     define('WP_DEBUG', ${WP_DEBUG,,});
     define('WP_DEBUG_LOG', ${WP_DEBUG_LOG,,});
@@ -60,7 +61,7 @@ fi
 # Wait for MySQL
 # --------------
 printf "=> Waiting for MySQL to initialize... \n"
-while ! mysqladmin ping --host=db --password=$DB_PASS --silent; do
+while ! mysqladmin ping --host=$DB_HOST --password=$DB_PASS --silent; do
   sleep 1
 done
 


### PR DESCRIPTION
I've used this image to migrate a WP installation away from a crummy shared-hosting service. The image was very convenient for getting up and running quickly, however it assumes the use of Compose. When I tried to deploy this to a Cloud66 cluster, I discovered the strict dependence on the  `db` hostname made deployment impossible.

The following change to the entrypoint adds support for a `DB_HOST` environment variable, which defaults to `db` to maintain the existing API, and which is used where the raw `db` hostname was otherwise used.