### PR TITLE
Critical Fix

### DIFF
--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
         zip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mysqli opcache
+    && docker-php-ext-install gd mysqli opcache zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
 RUN { \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update \
         zip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mysqli opcache
+    && docker-php-ext-install gd mysqli opcache zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
 RUN { \


### PR DESCRIPTION
Tried using the build this evening and it didn't work properly (even after working all day yesterday? Go figure). Did some digging and it looks like the root of the problem is that the zip extension isn't enabled so wp-cli is unable to unzip the initial wordpress download.

Fixed that.

Please test on your end to make sure this works for you.