### PR TITLE
Add version label for cache busting purposes + document phpmyadmin use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This changelog is for the Docker image. There might be changes to the gulpfile that are not listed here.
 
-## 0.12.1 - latest
+## 0.12.2 - latest
+- Add missing `exif` php extension to handle WordPress media upload metadata parsing.
+- Bump default base theme to `twentyseventeen`
+
+## 0.12.1
 - This project now maintains 2 separate `Dockerfile`, depending on the version of PHP you'd like to have installed.
 
 **Available Dockerfiles**:

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ We wrote a series of articles explaining in depth the philosophy behind this pro
 
 | PHP Version | Tags |
 | ----------- | ---- |
-| **7.0**     | `latest` `latest-php7.0` |
-| **5.6**     | `latest-php5.6` |
+| **7.0**     | `latest` `latest-php7.0` `<version>-php7.0` |
+| **5.6**     | `latest-php5.6` `<version>-php5.6`|
 
 If you need a specific version, look at the [Changelog](CHANGELOG.md)
 
@@ -62,8 +62,6 @@ version: '2'
 services:
   wordpress:
     image: visiblevc/wordpress:latest
-    links:
-      - db
     ports:
       - 8080:80
       - 443:443
@@ -93,6 +91,25 @@ services:
       MYSQL_ROOT_PASSWORD: root
 volumes:
   data: {}
+```
+
+**Need PHPMyAdmin? Add it as a service**
+
+```yml
+version: '2'
+services:
+  wordpress:
+    # same as above
+  db:
+    # same as above
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - 22222:80
+volumes:
+  data:
 ```
 
 ### Default Database Credentials

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visible-wordpress",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "scripts": {
     "wp": "wpcmd() { docker exec $(docker ps -lq) /bin/bash -c \"sudo -u www-data wp $(echo $@)\"; };wpcmd "
   },

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
         less \
         libpng12-dev \
         libjpeg-dev \
+        libxml2-dev \
         mariadb-client \
         unzip \
         sudo \
@@ -20,6 +21,7 @@ RUN apt-get update \
         gd \
         mysqli \
         opcache \
+        soap \
         zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -23,14 +23,15 @@ RUN apt-get update \
         zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
-RUN { \
-  echo 'opcache.memory_consumption=128'; \
-  echo 'opcache.interned_strings_buffer=8'; \
-  echo 'opcache.max_accelerated_files=4000'; \
-  echo 'opcache.revalidate_freq=2'; \
-  echo 'opcache.fast_shutdown=1'; \
-  echo 'opcache.enable_cli=1'; \
-} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN echo "memory_limit = 512M" > /usr/local/etc/php/php.ini \
+    && { \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # Install wp-cli, configure apache, & add scripts
 RUN curl \

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:5.6-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
-LABEL version 0.12.1-php5.6
+LABEL version 0.12.2-php5.6
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN apt-get update \
@@ -15,7 +15,12 @@ RUN apt-get update \
         zip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mysqli opcache zip
+    && docker-php-ext-install \
+        exif \
+        gd \
+        mysqli \
+        opcache \
+        zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
 RUN { \

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:5.6-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
+LABEL version 0.12.1-php5.6
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN apt-get update \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
         less \
         libpng12-dev \
         libjpeg-dev \
+        libxml2-dev \
         mariadb-client \
         unzip \
         sudo \
@@ -20,6 +21,7 @@ RUN apt-get update \
         gd \
         mysqli \
         opcache \
+        soap \
         zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -23,14 +23,15 @@ RUN apt-get update \
         zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
-RUN { \
-  echo 'opcache.memory_consumption=128'; \
-  echo 'opcache.interned_strings_buffer=8'; \
-  echo 'opcache.max_accelerated_files=4000'; \
-  echo 'opcache.revalidate_freq=2'; \
-  echo 'opcache.fast_shutdown=1'; \
-  echo 'opcache.enable_cli=1'; \
-} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+RUN echo "memory_limit = 512M" > /usr/local/etc/php/php.ini \
+    && { \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
 
 # Install wp-cli, configure apache, & add scripts
 RUN curl \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:7.0-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
+LABEL version 0.12.1-php7.0
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN apt-get update \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
-LABEL version 0.12.1-php7.0
+LABEL version 0.12.2-php7.0
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN apt-get update \
@@ -15,7 +15,12 @@ RUN apt-get update \
         zip \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mysqli opcache zip
+    && docker-php-ext-install \
+        exif \
+        gd \
+        mysqli \
+        opcache \
+        zip
 
 # Set recommended PHP.ini settings (see https://secure.php.net/manual/en/opcache.installation.php)
 RUN { \

--- a/run.sh
+++ b/run.sh
@@ -179,7 +179,7 @@ check_themes() {
     STATUS SKIP
     h2 "Checking for orphaned themes"
     while read -r theme_name; do
-      if [[ "$theme_name" == 'twentysixteen' ]]; then continue; fi
+      if [[ "$theme_name" == 'twentyseventeen' ]]; then continue; fi
       h3 "'$theme_name' no longer needed. Pruning"
       WP theme delete --quiet "$theme_name"
       STATUS $?


### PR DESCRIPTION
We can probably hold off merging this until the next update since there's nothing particularly important. Perhaps merge this with your fix for plugin/theme pruning?