### PR TITLE
add SERVER_NAME variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 This changelog is for the Docker image. There might be changes to the gulpfile that are not listed here.
 
-## 0.13.0 - latest
+## 0.14.0 - latest
+- Add `SERVER_NAME` variable to allow for quickly setting that directive in the apache config for users interested in running in production.
+
+## 0.13.0
 - Add `certbot` into the image to allow for easily obtaining and renewing SSL certificates
 
 ## 0.12.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,4 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
 volumes:
-  data: {}
+  data:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visible-wordpress",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "scripts": {
     "wp": "wpcmd() { docker exec $(docker ps -lq) /bin/bash -c \"sudo -u www-data wp $(echo $@)\"; };wpcmd "
   },

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:5.6-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
-LABEL version="0.13.0-php5.6"
+LABEL version="0.14.0-php5.6"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
@@ -44,7 +44,6 @@ RUN curl \
         -o /run.sh https://raw.githubusercontent.com/visiblevc/wordpress-starter/master/run.sh \
     && chmod +x /usr/local/bin/wp /run.sh \
     && sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf \
-    && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
     && a2enmod rewrite expires \
     && service apache2 restart
 

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.0-apache
 MAINTAINER Derek P Sifford <dereksifford@gmail.com>
-LABEL version="0.13.0-php7.0"
+LABEL version="0.14.0-php7.0"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \
@@ -44,7 +44,6 @@ RUN curl \
         -o /run.sh https://raw.githubusercontent.com/visiblevc/wordpress-starter/master/run.sh \
     && chmod +x /usr/local/bin/wp /run.sh \
     && sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf \
-    && echo "ServerName localhost" >> /etc/apache2/apache2.conf \
     && a2enmod rewrite expires \
     && service apache2 restart
 

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ DB_HOST=${DB_HOST:-'db'}
 DB_NAME=${DB_NAME:-'wordpress'}
 DB_PASS=${DB_PASS:-'root'}
 DB_PREFIX=${DB_PREFIX:-'wp_'}
+SERVER_NAME=${SERVER_NAME:-'localhost'}
 ADMIN_EMAIL=${ADMIN_EMAIL:-"admin@${DB_NAME}.com"}
 PERMALINKS=${PERMALINKS:-'/%year%/%monthnum%/%postname%/'}
 WP_DEBUG_DISPLAY=${WP_DEBUG_DISPLAY:-'true'}
@@ -47,6 +48,10 @@ core install:
   admin_email: $ADMIN_EMAIL
   skip-email: true
 EOF
+
+# Apache configuration
+# --------------------
+sed -i "s/#ServerName www.example.com/ServerName $SERVER_NAME/" /etc/apache2/sites-available/000-default.conf
 
 main() {
   h1 "Begin WordPress Installation"


### PR DESCRIPTION
Hey there, hypocrite here! 

I know I just got done saying we're env variable overloaded (I think yesterday?), but I deployed a site in production last night and the single-biggest annoyance was that I had to go into the container, navigate to the apache config file, and set the ServerName directive to the domain name prior to running `certbot --apache` (otherwise, things would get screwy with certbot).

This PR allows for users to set the `ServerName` directive in the `000-default.conf` on build, which negates the need to to anything but `certbot --apache` for getting SSL certificates.

Because of this option, setting `ServerName` to `localhost` was removed from the Dockerfile and placed in the run script.

Let me know what you think @karellm.