### PR TITLE
Denies Apache from seeing .yml files such as the wp-cli.yml file

### DIFF
--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -44,6 +44,7 @@ RUN curl \
         -o /run.sh https://raw.githubusercontent.com/visiblevc/wordpress-starter/master/run.sh \
     && chmod +x /usr/local/bin/wp /run.sh \
     && sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf \
+    && sed -i 's/<FilesMatch "^\\.ht">/<FilesMatch "^\.ht|\.yml">/g' /etc/apache2/apache2.conf \    
     && a2enmod rewrite expires \
     && service apache2 restart
 

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -44,6 +44,7 @@ RUN curl \
         -o /run.sh https://raw.githubusercontent.com/visiblevc/wordpress-starter/master/run.sh \
     && chmod +x /usr/local/bin/wp /run.sh \
     && sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf \
+    && sed -i 's/<FilesMatch "^\\.ht">/<FilesMatch "^\.ht|\.yml">/g' /etc/apache2/apache2.conf \
     && a2enmod rewrite expires \
     && service apache2 restart
 


### PR DESCRIPTION
The wp-cli.yml in the application root contains sensitive information needed during setup but never gets removed. Not sure if it needs to exist beyond the initial setup so as a stopgap measure this patch simply disallows Apache to serve any .yml files to the visitor so that information can't leak. If I'm missing some obvious reason why that information would be not fetch-able whilst running in production, let me know!