### PR TITLE
Addition to wp-config.php to allow https via reverse proxy

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -41,9 +41,9 @@ core config:
     define('WP_DEBUG', ${WP_DEBUG:-false});
     define('WP_DEBUG_LOG', ${WP_DEBUG_LOG:-false});
     define('WP_DEBUG_DISPLAY', ${WP_DEBUG_DISPLAY:-true});
-    if (\$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+    if (\$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
        \$_SERVER['HTTPS']='on';
-
+    }
     if (isset(\$_SERVER['HTTP_X_FORWARDED_HOST'])) {
        \$_SERVER['HTTP_HOST'] = \$_SERVER['HTTP_X_FORWARDED_HOST'];
     }

--- a/run.sh
+++ b/run.sh
@@ -41,6 +41,12 @@ core config:
     define('WP_DEBUG', ${WP_DEBUG:-false});
     define('WP_DEBUG_LOG', ${WP_DEBUG_LOG:-false});
     define('WP_DEBUG_DISPLAY', ${WP_DEBUG_DISPLAY:-true});
+    if (\$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+       \$_SERVER['HTTPS']='on';
+
+    if (isset(\$_SERVER['HTTP_X_FORWARDED_HOST'])) {
+       \$_SERVER['HTTP_HOST'] = \$_SERVER['HTTP_X_FORWARDED_HOST'];
+    }
 
 core install:
   url: ${AFTER_URL:-localhost:8080}


### PR DESCRIPTION
I tried to put this wordpress container behind a reverse proxy that terminates https requests and reroutes them in clear to a local container (I used traefik, but it could be anything) and the only way to make it work properly (no mixed content) is to allow wordpress to be aware of the fact that the request is a forwarded https request.
I believe that these lines, added to the wp-config.php file, are harmless for other use cases, but crucial for mine. 

Pull if you agree, and thanks for the great project!