### PR TITLE
add php7.2, remove deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 *.swp
 .c9
 .sass-cache/
+.vscode
 
 # Wordpress
 wp-content/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.16.0 - latest
+## 0.17.0 - latest
+
+### Minor
+- Add PHP 7.2 (`latest`, `latest-php7.2`, `0.17.0-php7.2`)
+- Add `DB_USER` config option to environment variables
+
+## 0.16.0
 - **BREAKING CHANGE:** Builds will now exit if any plugin or theme installs fail.
 - Improve logging.
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,44 @@
 # Visible Wordpress Starter
 
-A Docker Wordpress development environment by the team at [Visible](https://visible.vc/) and some awesome [contributors](https://github.com/visiblevc/wordpress-starter/graphs/contributors). Our goal is to make Wordpress development slightly less frustrating.
+A Docker Wordpress development environment by the team at [Visible](https://visible.vc/) and some
+awesome [contributors](https://github.com/visiblevc/wordpress-starter/graphs/contributors). Our goal
+is to make Wordpress development slightly less frustrating.
 
-- [Introduction](#introduction)
-- [Example](./example/)
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-- [Available Images](#available-images)
-- [Default Wordpress Admin Credentials](#default-wordpress-admin-credentials)
-- [Default Database Credentials](#default-database-credentials)
-- [Service Environment Variables](#service-environment-variables)
-  - [`wordpress`](#wordpress)
-  - [`db`](#db)
-- [Workflow Tips](#workflow-tips)
-  - [Using `wp-cli`](#using-wp-cli)
-  - [Working with Databases](#working-with-databases)
-- [Using in Production](#using-in-production)
-- [Contributing](#contributing)
+* [Introduction](#introduction)
+* [Example](./example/)
+* [Requirements](#requirements)
+* [Getting Started](#getting-started)
+* [Available Images](#available-images)
+* [Default Wordpress Admin Credentials](#default-wordpress-admin-credentials)
+* [Default Database Credentials](#default-database-credentials)
+* [Service Environment Variables](#service-environment-variables)
+  * [`wordpress`](#wordpress)
+  * [`db`](#db)
+* [Workflow Tips](#workflow-tips)
+  * [Using `wp-cli`](#using-wp-cli)
+  * [Working with Databases](#working-with-databases)
+* [Using in Production](#using-in-production)
+* [Contributing](#contributing)
 
 ### Introduction
 
 We wrote a series of articles explaining in depth the philosophy behind this project:
 
-- [Intro: A slightly less shitty WordPress developer workflow](https://visible.vc/engineering/wordpress-developer-workflow/)
-- [Part 1: Setup a local development environment for WordPress with Docker](https://visible.vc/engineering/docker-environment-for-wordpress/)
-- [Part 2: Setup an asset pipeline for WordPress theme development](https://visible.vc/engineering/asset-pipeline-for-wordpress-theme-development/)
-- [Part 3: Optimize your wordpress theme assets and deploy to S3](https://visible.vc/engineering/optimize-wordpress-theme-assets-and-deploy-to-s3-cloudfront/)
+* [Intro: A slightly less shitty WordPress developer workflow](https://visible.vc/engineering/wordpress-developer-workflow/)
+* [Part 1: Setup a local development environment for WordPress with Docker](https://visible.vc/engineering/docker-environment-for-wordpress/)
+* [Part 2: Setup an asset pipeline for WordPress theme development](https://visible.vc/engineering/asset-pipeline-for-wordpress-theme-development/)
+* [Part 3: Optimize your wordpress theme assets and deploy to S3](https://visible.vc/engineering/optimize-wordpress-theme-assets-and-deploy-to-s3-cloudfront/)
 
 ### Requirements
 
-Well, to run a Docker environment, you will need Docker. The Dockerfile is only for an Apache+PHP+Wordpress container, you will need a `MySQL` or `MariaDB` container to run a website. We use Docker Compose 1.6+ for the orchestration.
+Well, to run a Docker environment, you will need Docker. The Dockerfile is only for an
+Apache+PHP+Wordpress container, you will need a `MySQL` or `MariaDB` container to run a website. We
+use Docker Compose 1.6+ for the orchestration.
 
 ### Getting started
 
-This project has 2 parts: the Docker environment and a set of tools for theme development. To quickly get started, you can simply run the following:
+This project has 2 parts: the Docker environment and a set of tools for theme development. To
+quickly get started, you can simply run the following:
 
 ```
 # copy the files
@@ -46,15 +51,17 @@ cd wordpress-starter/example
 docker-compose up -d && docker-compose logs -f wordpress
 ```
 
-**NOTE:** If you run on MacOS with Docker in VirtualBox, you will want to forward the port by running this `VBoxManage controlvm vm-name natpf1 "tcp8080,tcp,127.0.0.1,8080,,8080"`. If you use another port than `8080`, change it in the command.
+**NOTE:** If you run on MacOS with Docker in VirtualBox, you will want to forward the port by
+running this `VBoxManage controlvm vm-name natpf1 "tcp8080,tcp,127.0.0.1,8080,,8080"`. If you use
+another port than `8080`, change it in the command.
 
 ### Available Images
 
-| PHP Version | Tags |
-| ----------- | ---- |
+| PHP Version | Tags                                        |
+| ----------- | ------------------------------------------- |
 | **7.1**     | `latest` `latest-php7.1` `<version>-php7.1` |
-| **7.0**     | `latest-php7.0` `<version>-php7.0` |
-| **5.6**     | `latest-php5.6` `<version>-php5.6`|
+| **7.0**     | `latest-php7.0` `<version>-php7.0`          |
+| **5.6**     | `latest-php5.6` `<version>-php5.6`          |
 
 If you need a specific version, look at the [Changelog](CHANGELOG.md)
 
@@ -62,50 +69,54 @@ If you need a specific version, look at the [Changelog](CHANGELOG.md)
 
 To access the Wordpress Admin at `/wp-admin`, the default values are as follows:
 
-Credential | Value | Notes
---- | --- | ---
-**Username or Email** | `root` or `admin@wordpress.com` | Can be changed with the `ADMIN_EMAIL` environment variable
-**Password** | `root` | Uses the same value as the `DB_PASS` environment variable |
+| Credential            | Value                           | Notes                                                      |
+| --------------------- | ------------------------------- | ---------------------------------------------------------- |
+| **Username or Email** | `root` or `admin@wordpress.com` | Can be changed with the `ADMIN_EMAIL` environment variable |
+| **Password**          | `root`                          | Uses the same value as the `DB_PASS` environment variable  |
 
 ### Default Database Credentials
 
-Credential | Value | Notes
---- | --- | ---
-**Hostname** | `db` | Can be changed with the `DB_HOST` environment variable  **NOTE:**: Must match database service name
-**Username** | `root` | |
-**Password** |  | Must be set using the `DB_PASS` environment variable
-**Database Name** | `wordpress` | Can be changed with the `DB_NAME` environment variable
-**Admin Email** | `admin@${DB_NAME}.com` | |
+| Credential        | Value                  | Notes                                                                                              |
+| ----------------- | ---------------------- | -------------------------------------------------------------------------------------------------- |
+| **Hostname**      | `db`                   | Can be changed with the `DB_HOST` environment variable **NOTE:**: Must match database service name |
+| **Username**      | `root`                 |                                                                                                    |
+| **Password**      |                        | Must be set using the `DB_PASS` environment variable                                               |
+| **Database Name** | `wordpress`            | Can be changed with the `DB_NAME` environment variable                                             |
+| **Admin Email**   | `admin@${DB_NAME}.com` |                                                                                                    |
 
 ### Service Environment Variables
+
 **Notes:**
-- Variables marked with ✅ are required
-- Single quotes must surround `boolean` environment variables
+
+* Variables marked with ✅ are required
+* Single quotes must surround `boolean` environment variables
 
 #### `wordpress`
 
-Variable | Default Value | Description
----|---|---
-`DB_PASS`✅ | | Password for the database. Value must match `MYSQL_ROOT_PASSWORD` set in the `db` service
-`DB_HOST` | `db` | Hostname for the database
-`DB_NAME` | `wordpress` | Name of the database
-`DB_PREFIX` | `wp_` | Prefix for the database
-`SERVER_NAME` | `localhost` | Set this to `<your-domain-name>.<your-domain-extension>` if you plan on obtaining SSL certificates
-`ADMIN_EMAIL` | `admin@${DB_NAME}.com` | Administrator email address
-`WP_DEBUG` | `'false'` | [Click here](https://codex.wordpress.org/WP_DEBUG) for more information
-`WP_DEBUG_DISPLAY` | `'false'` | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_DISPLAY) for more information
-`WP_DEBUG_LOG` | `'false'` | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_LOG) for more information
-`WP_VERSION` | `latest` | Specify the WordPress version to install. Accepts any valid semver number, `latest`, or `nightly` for beta builds.
-`THEMES` | | Comma-separated list of themes you want to install in either of the following forms<ul><li>`theme-slug`: Used when installing theme direct from WordPress.org</li><li>`[theme-slug]https://themesite.com/theme.zip`: Used when installing theme from URL</li></ul>
-`PLUGINS` | | Comma-separated list of plugins you want to install in either of the following forms:<ul><li>`plugin-slug`: Used when installing plugin direct from WordPress.org.</li><li>`[plugin-slug]http://pluginsite.com/plugin.zip`: Used when installing plugin from URL.</li></ul>
-`MULTISITE` | `'false'` | Set to `'true'` to enable multisite
-`PERMALINKS` | `/%year%/%monthnum%/%postname%/` | A valid WordPress permalink [structure tag](https://codex.wordpress.org/Using_Permalinks#Structure_Tags)
-`URL_REPLACE` | | Comma-separated string in the form of `current-url,replacement-url`<ul><li>When defined, `current-url` will be replaced with `replacement-url` on build (useful for development environments utilizing a database copied from a live site)<li>**Note:** If you are running Docker using Docker Machine, your replacement url MUST be the output of the following command: `echo $(docker-machine ip <your-machine-name>):8080`</li></ul>
+| Variable           | Default Value                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DB_USER`          | `root`                           | Username for both the database and the WordPress installation (if not importing existing)                                                                                                                                                                                                                                                                                                                                                |
+| `DB_PASS`✅        |                                  | Password for the database. Value must match `MYSQL_ROOT_PASSWORD` set in the `db` service                                                                                                                                                                                                                                                                                                                                                |
+| `DB_HOST`          | `db`                             | Hostname for the database                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `DB_NAME`          | `wordpress`                      | Name of the database                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `DB_PREFIX`        | `wp_`                            | Prefix for the database                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `SERVER_NAME`      | `localhost`                      | Set this to `<your-domain-name>.<your-domain-extension>` if you plan on obtaining SSL certificates                                                                                                                                                                                                                                                                                                                                       |
+| `ADMIN_EMAIL`      | `admin@${DB_NAME}.com`           | Administrator email address                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `WP_DEBUG`         | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG) for more information                                                                                                                                                                                                                                                                                                                                                                  |
+| `WP_DEBUG_DISPLAY` | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_DISPLAY) for more information                                                                                                                                                                                                                                                                                                                                                 |
+| `WP_DEBUG_LOG`     | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_LOG) for more information                                                                                                                                                                                                                                                                                                                                                     |
+| `WP_VERSION`       | `latest`                         | Specify the WordPress version to install. Accepts any valid semver number, `latest`, or `nightly` for beta builds.                                                                                                                                                                                                                                                                                                                       |
+| `THEMES`           |                                  | Comma-separated list of themes you want to install in either of the following forms<ul><li>`theme-slug`: Used when installing theme direct from WordPress.org</li><li>`[theme-slug]https://themesite.com/theme.zip`: Used when installing theme from URL</li></ul>                                                                                                                                                                       |
+| `PLUGINS`          |                                  | Comma-separated list of plugins you want to install in either of the following forms:<ul><li>`plugin-slug`: Used when installing plugin direct from WordPress.org.</li><li>`[plugin-slug]http://pluginsite.com/plugin.zip`: Used when installing plugin from URL.</li></ul>                                                                                                                                                              |
+| `MULTISITE`        | `'false'`                        | Set to `'true'` to enable multisite                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `PERMALINKS`       | `/%year%/%monthnum%/%postname%/` | A valid WordPress permalink [structure tag](https://codex.wordpress.org/Using_Permalinks#Structure_Tags)                                                                                                                                                                                                                                                                                                                                 |
+| `URL_REPLACE`      |                                  | Comma-separated string in the form of `current-url,replacement-url`<ul><li>When defined, `current-url` will be replaced with `replacement-url` on build (useful for development environments utilizing a database copied from a live site)<li>**Note:** If you are running Docker using Docker Machine, your replacement url MUST be the output of the following command: `echo $(docker-machine ip <your-machine-name>):8080`</li></ul> |
 
 #### `db`
-Variable | Default Value | Description
----|---|---
-`MYSQL_ROOT_PASSWORD`✅ | | Must match `DB_PASS` of the `wordpress` service
+
+| Variable                | Default Value | Description                                     |
+| ----------------------- | ------------- | ----------------------------------------------- |
+| `MYSQL_ROOT_PASSWORD`✅ |               | Must match `DB_PASS` of the `wordpress` service |
 
 ## Workflow Tips
 
@@ -120,7 +131,9 @@ npm run wp db import /data/database.sql
 
 ### Working with Databases
 
-If you have an exported `.sql` file from an existing website, drop the file into the `data/` folder. The first time you run the container, it will detect the SQL dump and use it as a database. If it doesn't find one, it will create a fresh database.
+If you have an exported `.sql` file from an existing website, drop the file into the `data/` folder.
+The first time you run the container, it will detect the SQL dump and use it as a database. If it
+doesn't find one, it will create a fresh database.
 
 If the SQL dump changes for some reason, you can reload the database by running:
 
@@ -134,7 +147,10 @@ If you want to create a dump of your development database, you can run:
 docker-compose exec wordpress /bin/bash 'wp db export /data --allow-root'
 ```
 
-Finally, sometimes your development environment runs on a different domain than your live one. The live will be `example.com` and the development `localhost:8080`. This project does a search and replace for you. You can set the `URL_REPLACE: example.com,localhost:8080` environment variable in the `docker-compose.yml`.
+Finally, sometimes your development environment runs on a different domain than your live one. The
+live will be `example.com` and the development `localhost:8080`. This project does a search and
+replace for you. You can set the `URL_REPLACE: example.com,localhost:8080` environment variable in
+the `docker-compose.yml`.
 
 ## Using in Production
 
@@ -164,9 +180,12 @@ services:
 
 ### SSL Certificates
 
-We highly recommend securing your site with SSL encryption. The Let's Encrypt and Certbot projects have made doing this both free (as in beer) and painless. We've incorporated these projects into this project.
+We highly recommend securing your site with SSL encryption. The Let's Encrypt and Certbot projects
+have made doing this both free (as in beer) and painless. We've incorporated these projects into
+this project.
 
-Assuming your site is running on your production host, follow the below steps to obtain and renew SSL certificates.
+Assuming your site is running on your production host, follow the below steps to obtain and renew
+SSL certificates.
 
 #### Obtaining Certificates
 
@@ -196,4 +215,5 @@ root@4e16c7fe4a10:/app# certbot renew
 
 ## Contributing
 
-You can find Development instructions in the [Wiki](https://github.com/visiblevc/wordpress-starter/wiki/Development).
+You can find Development instructions in the
+[Wiki](https://github.com/visiblevc/wordpress-starter/wiki/Development).

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env bash
+set -e
 
 npm_package_version="${npm_package_version?Script must be run using npm}"
 
 docker login
-[ $? -eq 1 ] && exit 0
 
 # NOTE: Not building this stack of images concurrently due to a known issue
 # with docker concurrent builds. https://github.com/moby/moby/issues/9656
-
-set -e
 
 docker build \
   -t "visiblevc/wordpress:latest" \
@@ -17,7 +15,6 @@ docker build \
 ./php7.2/
 
 docker build \
-  -t "visiblevc/wordpress:latest" \
   -t "visiblevc/wordpress:latest-php7.1" \
   -t "visiblevc/wordpress:$npm_package_version-php7.1" \
 ./php7.1/

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ docker login
 # NOTE: Not building this stack of images concurrently due to a known issue
 # with docker concurrent builds. https://github.com/moby/moby/issues/9656
 
+set -e
+
 docker build \
   -t "visiblevc/wordpress:latest" \
   -t "visiblevc/wordpress:latest-php7.2" \

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,12 @@ docker login
 
 docker build \
   -t "visiblevc/wordpress:latest" \
+  -t "visiblevc/wordpress:latest-php7.2" \
+  -t "visiblevc/wordpress:$npm_package_version-php7.2" \
+./php7.2/
+
+docker build \
+  -t "visiblevc/wordpress:latest" \
   -t "visiblevc/wordpress:latest-php7.1" \
   -t "visiblevc/wordpress:$npm_package_version-php7.1" \
 ./php7.1/

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wordpress:
-    image: visiblevc/wordpress:0.16.0-php7.1
+    image: visiblevc/wordpress:0.17.0-php7.1
     ports:
       - 8080:80
       - 443:443

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visiblevc-wordpress",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A slightly less shitty wordpress development workflow",
   "main": "index.js",
   "repository": "https://github.com/visiblevc/wordpress-starter.git",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "MIT",
   "scripts": {
     "build": "./build.sh",
-    "update-version": "for file in './php7.0/Dockerfile' './php5.6/Dockerfile' './php7.1/Dockerfile'; do sed -Ei \"s/(version=\\\")(.*)(-)/\\1$npm_package_version\\3/g\" \"$file\"; done && sed -Ei \"s/(wordpress:)(.*)(-)/\\1$npm_package_version\\3/g\" ./example/docker-compose.yml"
+    "update-version": "for file in './php7.0/Dockerfile' './php5.6/Dockerfile' './php7.1/Dockerfile' './php7.2/Dockerfile'; do sed -Ei \"s/(version=\\\")(.*)(-)/\\1$npm_package_version\\3/g\" \"$file\"; done && sed -Ei \"s/(wordpress:)(.*)(-)/\\1$npm_package_version\\3/g\" ./example/docker-compose.yml"
   }
 }

--- a/php5.6/Dockerfile
+++ b/php5.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:5.6-apache
 ENV TERM=xterm
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
-      version="0.16.0-php5.6"
+      version="0.17.0-php5.6"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \

--- a/php7.0/Dockerfile
+++ b/php7.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.0-apache
 ENV TERM=xterm
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
-      version="0.16.0-php7.0"
+      version="0.17.0-php7.0"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \

--- a/php7.1/Dockerfile
+++ b/php7.1/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.1-apache
 ENV TERM=xterm
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
-      version="0.16.0-php7.1"
+      version="0.17.0-php7.1"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list \

--- a/php7.2/Dockerfile
+++ b/php7.2/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.2-apache
 ENV TERM=xterm
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
-      version="0.16.0-php7.2"
+      version="0.17.0-php7.2"
 
 # Install base requirements & sensible defaults + required PHP extensions
 RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \

--- a/php7.2/Dockerfile
+++ b/php7.2/Dockerfile
@@ -1,0 +1,60 @@
+FROM php:7.2-apache
+ENV TERM=xterm
+LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
+      version="0.16.0-php7.2"
+
+# Install base requirements & sensible defaults + required PHP extensions
+RUN echo "deb http://ftp.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bash-completion \
+        less \
+        libpng-dev \
+        libjpeg-dev \
+        libxml2-dev \
+        mariadb-client \
+        unzip \
+        sudo \
+        vim \
+        zip \
+    && DEBIAN_FRONTEND=noninteractive apt-get -t stretch-backports install -y \
+        python-certbot-apache \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+    && docker-php-ext-install \
+        exif \
+        gd \
+        mysqli \
+        opcache \
+        soap \
+        zip \
+    # See https://secure.php.net/manual/en/opcache.installation.php
+    && echo 'memory_limit = 512M' > /usr/local/etc/php/php.ini \
+    && { \
+        echo 'opcache.memory_consumption=128'; \
+        echo 'opcache.interned_strings_buffer=8'; \
+        echo 'opcache.max_accelerated_files=4000'; \
+        echo 'opcache.revalidate_freq=2'; \
+        echo 'opcache.fast_shutdown=1'; \
+        echo 'opcache.enable_cli=1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+# Install wp-cli, configure apache, add scripts, create install directory & symlink
+RUN curl -s \
+        -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+        -o /run.sh https://raw.githubusercontent.com/visiblevc/wordpress-starter/master/run.sh \
+    && chmod +x /usr/local/bin/wp /run.sh \
+    && curl -s \
+        https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash | \
+        sed -e "s/wp cli completions/wp cli completions --allow-root/" > /etc/bash_completion.d/wp-cli \
+    && sed -i 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf \
+    && echo "ServerName localhost" | tee /etc/apache2/conf-available/fqdn.conf && a2enconf fqdn \
+    && a2enmod rewrite expires \
+    && service apache2 restart \
+    && mkdir -p /app ~/.wp-cli \
+    && rm -fr /var/www/html \
+    && ln -s /app /var/www/html
+
+WORKDIR /app
+EXPOSE 80 443
+CMD ["/run.sh"]


### PR DESCRIPTION
cc: @karellm

**Questions:**
- Should we fully remove php5.6 from this repo? (My vote is yes -- historic dockerfiles will always exist on dockerhub).

**Notes:**
- The php7.2 image uses Debian Stretch, the others use Debian Jessie -- Updated the sources list accordingly.
- Another difference in the php7.2 image is the the PHP image uses the "slim" version of the distro (i.e., `debian:stretch-slim`). The others use the standard version (i.e. `debian:jessie`)

**TODO:**
- [x] Update README.md to include `DB_USER`
- [x] Version bump (minor semver)
 - [x] Build and push to dockerhub

**Future changes:** 
- I still think we should convert the run script into python, since we depend on it for certbot. Benefit is easier maintenance and also will allow us to run build steps concurrently. Planning on working on that as soon as time allows.
- In addition to above, I think it would be nice to come up with a better way to allow both configuration variables and configuration tasks to be extended without having to rebuild the base image. I have some ideas on how to do both of these things, but just writing this down in case you might have something better in mind.

Closes #119

Let me know what you think.