### PR TITLE
Add hints for ubuntu users

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - SYS_ADMIN
     devices:
       - /dev/fuse
+    security_opt:  # May not be required on non-ubuntu-based systems.
+      - apparmor:unconfined
 
     ports:
       - 8080:80

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,9 @@ if ! sudo mount -a 2>/dev/null; then
         - SYS_ADMIN
         devices:
         - /dev/fuse
+        # ubuntu-based machines may require the following setting:
+        security_opt:
+          - apparmor:unconfined
     ___
 
     OR (use first option if possible)


### PR DESCRIPTION
The recent PR #136 added the need for the WordPress container to introduce bindfs, which requires in turn CAP_SYS_ADMIN.

As reported on #136 Ubuntu users require a `security_opt` setting. 

This PR adds a couple of hints for such people.

I have used the prior configuration successfully on Amazon Linux and macOS, but I needed to add these additional configurations in order to get running w/ Ubuntu.

Thanks!