### PR TITLE
add redis support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.19.0 - latest
+## 0.20.0 - latest
+
+### Minor
+
+- Add support for Redis object caching.
+- Allow user to specify a different database charset via environment variable (#137)
+
+## 0.19.0
 
 **BREAKING CHANGE:** The WordPress service must now be configured in one of the following ways:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,21 @@ RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/
         bash-completion \
         bindfs \
         less \
-        libpng-dev \
         libjpeg-dev \
+        libpng-dev \
         libxml2-dev \
+        libzip-dev \
         mariadb-client \
-        unzip \
         sudo \
+        unzip \
         vim \
         zip \
     && DEBIAN_FRONTEND=noninteractive apt-get -t $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports install -y \
         python-certbot-apache \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+    && docker-php-ext-configure zip --with-libzip \
+    && yes no | pecl install redis \
     && docker-php-ext-install \
         exif \
         gd \
@@ -30,6 +33,7 @@ RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/
         opcache \
         soap \
         zip \
+    && docker-php-ext-enable redis \
     # See https://secure.php.net/manual/en/opcache.installation.php
     && echo 'memory_limit = 512M' > /usr/local/etc/php/php.ini \
     && { \


### PR DESCRIPTION
This PR simply adds support for Redis object caching. Nothing particularly interesting or fancy.

cc: @karellm 

**Edit:** The reason for the tweaks to the zip configuration is because there was a warning message that showed up during build unrelated to the redis changes that stated libzip was being removed as a dependency of PHP soon and needed to be installed manually. 