### PR TITLE
perform db update on import + improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## 0.20.0 - latest
+## 0.21.0 - latest
+
+### Minor
+
+- Automatically perform a WordPress database update after importing, if needed.
+
+### Chore
+
+- Update example files and error messages related to bindfs.
+
+## 0.20.0
 
 ### Minor
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,38 +1,41 @@
-version: '3'
+version: "3"
 services:
-  wordpress:
-    image: visiblevc/wordpress
+    wordpress:
+        image: visiblevc/wordpress
 
-    # required for mounting bindfs
-    cap_add:
-      - SYS_ADMIN
-    devices:
-      - /dev/fuse
+        # required for mounting bindfs
+        cap_add:
+            - SYS_ADMIN
+        devices:
+            - /dev/fuse
+        # required on certain cloud hosts
+        security_opt:
+            - apparmor:unconfined
 
-    ports:
-      - 8080:80
-      - 443:443
-    volumes:
-      - ./data:/data
-    environment:
-      DB_NAME: wordpress
-      DB_PASS: root
-      PLUGINS: >-
-        academic-bloggers-toolkit
-        co-authors-plus
-        [WP-API]https://github.com/WP-API/WP-API/archive/master.zip
+        ports:
+            - 8080:80
+            - 443:443
+        volumes:
+            - ./data:/data
+        environment:
+            DB_NAME: wordpress
+            DB_PASS: root
+            PLUGINS: >-
+                academic-bloggers-toolkit
+                co-authors-plus
+                [WP-API]https://github.com/WP-API/WP-API/archive/master.zip
 
-  db:
-    image: mariadb:10  # or mysql:5.7
-    volumes:
-      - data:/var/lib/mysql
-    environment:
-      MYSQL_ROOT_PASSWORD: root
+    db:
+        image: mariadb:10 # or mysql:5.7
+        volumes:
+            - data:/var/lib/mysql
+        environment:
+            MYSQL_ROOT_PASSWORD: root
 
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    ports:
-      - 22222:80
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin
+        ports:
+            - 22222:80
 
 volumes:
-  data:
+    data:

--- a/run.sh
+++ b/run.sh
@@ -8,11 +8,14 @@ if ! sudo mount -a 2>/dev/null; then
     Be sure your service is configured with the following options:
     ___
     services:
-    wordpress:
+      wordpress:
         cap_add:
-        - SYS_ADMIN
+          - SYS_ADMIN
         devices:
-        - /dev/fuse
+          - /dev/fuse
+        # needed on certain cloud hosts
+        security_opt:
+          - apparmor:unconfined
     ___
 
     OR (use first option if possible)
@@ -191,6 +194,8 @@ check_database() {
             "$(wp option get siteurl)" \
             "$URL_REPLACE" |& logger
     fi
+
+    wp --color core update-db |& logger
 }
 
 # Install / remove plugins based on $PLUGINS in parallel threads


### PR DESCRIPTION
This PR adds an extremely minor change that mitigates a small annoyance.

Typically, if a user imports an existing database into a `nightly` wordpress site, when logging it they'll be hit with a "you must update your database to continue" message. This PR adds a check that automatically does this on build.

This PR also fixes minor documentation issues.

Once approved, I'll build targeting the latest builds of each PHP minor version that we're tracking (we're behind a few).

cc: @karellm