### PR TITLE
add /docker-entrypoint-initwp.d/ init scripts directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor
 
+- Add `php7.3`
 - Add `/docker-entrypoint-initwp.d/` directory check to allow users to mount and run arbitrary scripts on build.
 - Use `twentynineteen` theme by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.21.0 - latest
+## 0.22.0 - latest
+
+### Minor
+
+- Add `/docker-entrypoint-initwp.d/` directory check to allow users to mount and run arbitrary scripts on build.
+- Use `twentynineteen` theme by default.
+
+## 0.21.0
 
 ### Minor
 

--- a/README.md
+++ b/README.md
@@ -5,31 +5,31 @@ A Docker Wordpress development environment by the team at
 [contributors](https://github.com/visiblevc/wordpress-starter/graphs/contributors).
 Our goal is to make Wordpress development slightly less frustrating.
 
-*   [Introduction](#introduction)
-*   [Example](./example/)
-*   [Requirements](#requirements)
-*   [Getting Started](#getting-started)
-*   [Available Images](#available-images)
-*   [Default Wordpress Admin Credentials](#default-wordpress-admin-credentials)
-*   [Default Database Credentials](#default-database-credentials)
-*   [Service Environment Variables](#service-environment-variables)
-    *   [`wordpress`](#wordpress)
-    *   [`db`](#db)
-*   [Workflow Tips](#workflow-tips)
-    *   [Using `wp-cli`](#using-wp-cli)
-    *   [Working with Databases](#working-with-databases)
-*   [Using in Production](#using-in-production)
-*   [Contributing](#contributing)
+-   [Introduction](#introduction)
+-   [Example](./example/)
+-   [Requirements](#requirements)
+-   [Getting Started](#getting-started)
+-   [Available Images](#available-images)
+-   [Default Wordpress Admin Credentials](#default-wordpress-admin-credentials)
+-   [Default Database Credentials](#default-database-credentials)
+-   [Service Environment Variables](#service-environment-variables)
+    -   [`wordpress`](#wordpress)
+    -   [`db`](#db)
+-   [Workflow Tips](#workflow-tips)
+    -   [Using `wp-cli`](#using-wp-cli)
+    -   [Working with Databases](#working-with-databases)
+-   [Using in Production](#using-in-production)
+-   [Contributing](#contributing)
 
 ### Introduction
 
 We wrote a series of articles explaining in depth the philosophy behind this
 project:
 
-*   [Intro: A slightly less shitty WordPress developer workflow](https://visible.vc/engineering/wordpress-developer-workflow/)
-*   [Part 1: Setup a local development environment for WordPress with Docker](https://visible.vc/engineering/docker-environment-for-wordpress/)
-*   [Part 2: Setup an asset pipeline for WordPress theme development](https://visible.vc/engineering/asset-pipeline-for-wordpress-theme-development/)
-*   [Part 3: Optimize your wordpress theme assets and deploy to S3](https://visible.vc/engineering/optimize-wordpress-theme-assets-and-deploy-to-s3-cloudfront/)
+-   [Intro: A slightly less shitty WordPress developer workflow](https://visible.vc/engineering/wordpress-developer-workflow/)
+-   [Part 1: Setup a local development environment for WordPress with Docker](https://visible.vc/engineering/docker-environment-for-wordpress/)
+-   [Part 2: Setup an asset pipeline for WordPress theme development](https://visible.vc/engineering/asset-pipeline-for-wordpress-theme-development/)
+-   [Part 3: Optimize your wordpress theme assets and deploy to S3](https://visible.vc/engineering/optimize-wordpress-theme-assets-and-deploy-to-s3-cloudfront/)
 
 ### Requirements
 
@@ -62,7 +62,8 @@ use another port than `8080`, change it in the command.
 
 | PHP Version | Tags                                        |
 | ----------- | ------------------------------------------- |
-| **7.2**     | `latest` `latest-php7.2` `<version>-php7.2` |
+| **7.3**     | `latest` `latest-php7.3` `<version>-php7.3` |
+| **7.2**     | `latest-php7.2` `<version>-php7.2`          |
 | **7.1**     | `latest-php7.1` `<version>-php7.1`          |
 | **7.0**     | `latest-php7.0` `<version>-php7.0`          |
 | **5.6**     | `latest-php5.6` `<version>-php5.6`          |
@@ -92,8 +93,8 @@ To access the Wordpress Admin at `/wp-admin`, the default values are as follows:
 
 **Notes:**
 
-*   Variables marked with ✅ are required
-*   Single quotes must surround `boolean` environment variables
+-   Variables marked with ✅ are required
+-   Single quotes must surround `boolean` environment variables
 
 #### `wordpress`
 
@@ -104,10 +105,10 @@ To access the Wordpress Admin at `/wp-admin`, the default values are as follows:
 | `DB_HOST`          | `db`                             | Hostname for the database                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `DB_NAME`          | `wordpress`                      | Name of the database                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `DB_PREFIX`        | `wp_`                            | Prefix for the database                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `DB_CHARSET`       | `utf8`                           | Select a charset for the wordpress database (legacy versions might not be utf8)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `DB_CHARSET`       | `utf8`                           | Select a charset for the wordpress database (legacy versions might not be utf8)                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `SERVER_NAME`      | `localhost`                      | Set this to `<your-domain-name>.<your-top-level-domain>` if you plan on obtaining SSL certificates                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `ADMIN_EMAIL`      | `admin@${DB_NAME}.com`           | Administrator email address                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `WP_LOCALE`        | `en_US`                          | Set the site language                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `WP_LOCALE`        | `en_US`                          | Set the site language                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `WP_DEBUG`         | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG) for more information                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `WP_DEBUG_DISPLAY` | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_DISPLAY) for more information                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `WP_DEBUG_LOG`     | `'false'`                        | [Click here](https://codex.wordpress.org/WP_DEBUG#WP_DEBUG_LOG) for more information                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -167,24 +168,24 @@ the `URL_REPLACE: localhost:8080` environment variable in the
 
 ```yml
 # If something isn't shown, assume it's the same as the examples above
-version: '3'
+version: "3"
 services:
-  wordpress:
-    ports:
-      - 80:80
-      - 443:443
-    restart: always
-    environment:
-      SERVER_NAME: mysite.com
-      DB_PASS: ${SECURE_PASSWORD} # Stored in .env file
-    volumes:
-      - ./letsencrypt:/etc/letsencrypt
-      - ./data:/data
-      # anything else you'd like to be able to back up
-  db:
-    restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: ${SECURE_PASSWORD} # Stored in .env file
+    wordpress:
+        ports:
+            - 80:80
+            - 443:443
+        restart: always
+        environment:
+            SERVER_NAME: mysite.com
+            DB_PASS: ${SECURE_PASSWORD} # Stored in .env file
+        volumes:
+            - ./letsencrypt:/etc/letsencrypt
+            - ./data:/data
+            # anything else you'd like to be able to back up
+    db:
+        restart: always
+        environment:
+            MYSQL_ROOT_PASSWORD: ${SECURE_PASSWORD} # Stored in .env file
 ```
 
 ### SSL Certificates

--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,10 @@ set -e
 
 # Ascending order is important here
 declare -a php_versions=(
-    5.6
     7.0
     7.1
     7.2
+    7.3
 )
 declare npm_package_version="${npm_package_version?Script must be run using npm}"
 declare dockerfile_dir

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             - 443:443
         volumes:
             - ./data:/data
+            - ./scripts:/docker-entrypoint-initwp.d
         environment:
             DB_NAME: wordpress
             DB_PASS: root

--- a/example/scripts/init.sh
+++ b/example/scripts/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+wp plugin activate my-plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visiblevc-wordpress",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A slightly less shitty wordpress development workflow",
   "main": "index.js",
   "repository": "https://github.com/visiblevc/wordpress-starter.git",

--- a/run.sh
+++ b/run.sh
@@ -47,6 +47,7 @@ fi
 # -------------
 mkdir -p ~/.wp-cli
 echo -e "
+path: /app
 apache_modules:
     - mod_rewrite
 
@@ -124,6 +125,13 @@ main() {
             "${PERMALINKS:-/%year%/%monthnum%/%postname%/}" |& logger
     fi
 
+    if [[ -e /docker-entrypoint-initwp.d ]]; then
+        h2 'Executing user init scripts'
+        for file in /docker-entrypoint-initwp/*; do
+            [[ -x $file ]] && "$file"
+        done
+    fi
+
     h1 'WordPress Configuration Complete!'
 
     sudo rm -f /var/run/apache2/apache2.pid
@@ -161,7 +169,7 @@ init() {
 
     # If no theme dependencies or volumes exist, fall back to default
     if [[ ${#theme_deps[@]} == 0 && $(check_volumes -t) == "" ]]; then
-        theme_deps[twentyseventeen]=twentyseventeen
+        theme_deps[twentynineteen]=twentynineteen
     fi
 
     sudo chown -R admin:admin /app

--- a/run.sh
+++ b/run.sh
@@ -127,7 +127,7 @@ main() {
 
     if [[ -e /docker-entrypoint-initwp.d ]]; then
         h2 'Executing user init scripts'
-        for file in /docker-entrypoint-initwp/*; do
+        for file in /docker-entrypoint-initwp.d/*; do
             [[ -x $file ]] && "$file"
         done
     fi


### PR DESCRIPTION
This PR adds a small feature that simply follows the format of how MySQL and MariaDB have for allowing users to run arbitrary init scripts after build completion. Let me know if you'd like me to explain further and I'd be glad to do so.

I added an example into the `/examples` directory of this functionality in action.

Also, this bumps the default theme to `twentynineteen`.

Ping: @karellm