### PR TITLE
add missing site health extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.22.0 - latest
+## 0.23.0 - latest
+
+### Minor 
+
+- Add missing `bcmath` and `imagick` PHP extensions recommended by WordPress 5.2's Health Check.
+
+## 0.22.0
 
 ### Minor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,22 @@
-ARG PHP_VERSION=7.2
+ARG PHP_VERSION=7.3
 FROM php:${PHP_VERSION}-apache
 ARG VERSION=latest
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
       version="${VERSION}-php${PHP_VERSION}"
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install base requirements & sensible defaults + required PHP extensions
+# hadolint ignore=DL3008
 RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports main" >> /etc/apt/sources.list \
     && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
         bash-completion \
         bindfs \
+        ghostscript \
         less \
         libjpeg-dev \
+        libmagickwand-dev \
         libpng-dev \
         libxml2-dev \
         libzip-dev \
@@ -20,22 +25,25 @@ RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/
         unzip \
         vim \
         zip \
-    && DEBIAN_FRONTEND=noninteractive apt-get -t $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports install -y \
+    && apt-get -t "$(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports" install -y --no-install-recommends \
         python-certbot-apache \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
     && docker-php-ext-configure zip --with-libzip \
-    && yes no | pecl install redis \
+    && pecl install imagick \
+    && pecl install redis \
     && docker-php-ext-install \
+        bcmath \
         exif \
         gd \
         mysqli \
         opcache \
         soap \
         zip \
+    && docker-php-ext-enable imagick \
     && docker-php-ext-enable redis \
     # See https://secure.php.net/manual/en/opcache.installation.php
-    && echo 'memory_limit = 512M' > /usr/local/etc/php/php.ini \
+    && echo 'memory_limit = 512M' >> /usr/local/etc/php/php.ini \
     && { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
@@ -53,8 +61,7 @@ RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/
         -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
         -o /etc/bash_completion.d/wp-cli https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash \
     && a2enconf fqdn \
-    && a2enmod rewrite expires \
-    && service apache2 restart
+    && a2enmod rewrite expires
 
 # Add admin superuser, create install directory, adjust perms, & add symlink
 COPY run.sh /run.sh


### PR DESCRIPTION
WordPress 5.2 now comes with a "Site Health" feature. Currently, this feature prints out a warning due to the fact that the image didn't have `bcmath` or `imagick` PHP extensions installed.

This PR installs and enables those extensions, which fixes those warnings.

Let me know if you have any questions.

Ping: @karellm