### PR TITLE
greatly simplify runtime script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -187,22 +187,26 @@ check_database() {
 
     wp db create |& logger
 
+    wp core install |& logger
+
     for file in /data/*.sql; do
+        h2 "Importing $file (this might take a while)..."
         wp db import "$file" |& logger
         ((num_imported++))
     done
 
-    if ((num_imported < 0)); then
-        wp core install |& logger
-    else
-        [[ -n $URL_REPLACE ]] \
-            && wp search-replace \
+    if ((num_imported > 0)); then
+        if [[ -n $URL_REPLACE ]]; then
+            h2 "Replacing URLs in database (this might take a while)..."
+            wp search-replace \
                 --skip-columns=guid \
                 --report-changed-only \
                 --no-report \
                 "$(wp option get siteurl)" \
                 "$URL_REPLACE" |& logger
+        fi
 
+        h2 'Updating database...'
         wp core update-db |& logger
     fi
 }


### PR DESCRIPTION
This PR seeks to greatly simplify the process of bootstrapping a wordpress installation from how we've done it in the past.

Previously, there was no way to do a clean install of wordpress without default plugins and themes, so we did a really complex method of checking for dependencies and then went through and manually deletes plugins/themes that didn't check out. There are several problems/quirks with doing it this way and I think we've talked about them in the past and just delt with them.

Now wp-cli allows you to download wordpress without the `wp-content` directory. So there really is no need to do this convoluted volume check anymore.

So that's the biggest change I made. I did another quick once over and made sure everything else checked out still and adjusted misc stuff during that little process (I'll look and comment on notable stuff inline in this PR if there are any).

Ping @karellm