### PR TITLE
fix small bug in run.sh + drop support for php < 7.2 + update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Changelog
 
-## 0.23.0 - latest
+## 0.25.1 - latest
+
+### Minor
+
+- Drop PHP 7.0 and 7.1 images.
+- Add PHP 7.4 image.
+
+### Patch
+
+- Fix bug in run.sh resulting from an invalid flag given to `find`
+
+## 0.25.0
+
+### Minor
+
+- Make runtime script much simpler and more reliable. #165 
+- Increase verbosity of logging related to database interactions. #165 
+
+## 0.24.0
+
+### Minor
+
+* feat: bump default theme install to "twentytwenty"
+* feat: increase `upload_max_filesize` to `50M`
+
+### Patch
+
+* fix: include "must-use" plugins in plugin volume check
+* fix: add --create-dirs to curl in dockerfile
+* fix: improve plugin volumes check to also include plugins that are a single php file
+
+## 0.23.0
 
 ### Minor 
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,9 @@ use another port than `8080`, change it in the command.
 
 | PHP Version | Tags                                        |
 | ----------- | ------------------------------------------- |
+| **7.4**     | `latest` `latest-php7.4` `<version>-php7.4` |
 | **7.3**     | `latest` `latest-php7.3` `<version>-php7.3` |
 | **7.2**     | `latest-php7.2` `<version>-php7.2`          |
-| **7.1**     | `latest-php7.1` `<version>-php7.1`          |
-| **7.0**     | `latest-php7.0` `<version>-php7.0`          |
-| **5.6**     | `latest-php5.6` `<version>-php5.6`          |
 
 If you need a specific version, look at the [Changelog](CHANGELOG.md)
 

--- a/build.sh
+++ b/build.sh
@@ -3,22 +3,13 @@ set -e
 
 : "${npm_package_version?Script must be ran using npm}"
 
-# Ascending order is important here
-declare -a php_versions=(
-    7.2
-    7.3
-    7.4
-)
-
-# NOTE: Not building this stack of images concurrently due to a known issue
-# with docker concurrent builds. https://github.com/moby/moby/issues/9656
-for php_version in "${php_versions[@]}"; do
+for dir in ./images/*; do
     docker build \
-        --build-arg PHP_VERSION="$php_version" \
+        -f "$dir/Dockerfile" \
         --build-arg VERSION="$npm_package_version" \
         -t "visiblevc/wordpress:latest" \
-        -t "visiblevc/wordpress:latest-php${php_version}" \
-        -t "visiblevc/wordpress:$npm_package_version-php${php_version}" \
+        -t "visiblevc/wordpress:latest-php${dir##*/}" \
+        -t "visiblevc/wordpress:$npm_package_version-php${dir##*/}" \
         .
 done
 

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+: "${npm_package_version?Script must be ran using npm}"
+
 # Ascending order is important here
 declare -a php_versions=(
-    7.0
-    7.1
     7.2
     7.3
+    7.4
 )
-declare npm_package_version="${npm_package_version?Script must be run using npm}"
-declare dockerfile_dir
-dockerfile_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # NOTE: Not building this stack of images concurrently due to a known issue
 # with docker concurrent builds. https://github.com/moby/moby/issues/9656
@@ -21,7 +19,7 @@ for php_version in "${php_versions[@]}"; do
         -t "visiblevc/wordpress:latest" \
         -t "visiblevc/wordpress:latest-php${php_version}" \
         -t "visiblevc/wordpress:$npm_package_version-php${php_version}" \
-        "$dockerfile_dir"
+        .
 done
 
 echo "

--- a/images/7.2/Dockerfile
+++ b/images/7.2/Dockerfile
@@ -1,8 +1,7 @@
-ARG PHP_VERSION=7.3
-FROM php:${PHP_VERSION}-apache
+FROM php:7.2-apache
 ARG VERSION=latest
 LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
-      version="${VERSION}-php${PHP_VERSION}"
+      version="${VERSION}-php7.2"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/images/7.3/Dockerfile
+++ b/images/7.3/Dockerfile
@@ -1,0 +1,95 @@
+FROM php:7.3-apache
+ARG VERSION=latest
+LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
+      version="${VERSION}-php7.3"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install base requirements & sensible defaults + required PHP extensions
+# hadolint ignore=DL3008
+RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash-completion \
+        bindfs \
+        ghostscript \
+        less \
+        libjpeg-dev \
+        libmagickwand-dev \
+        libpng-dev \
+        libxml2-dev \
+        libzip-dev \
+        mariadb-client \
+        sudo \
+        unzip \
+        vim \
+        zip \
+    && apt-get -t "$(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports" install -y --no-install-recommends \
+        python-certbot-apache \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+    && docker-php-ext-configure zip --with-libzip \
+    && pecl install imagick \
+    && pecl install redis \
+    && docker-php-ext-install \
+        bcmath \
+        exif \
+        gd \
+        mysqli \
+        opcache \
+        soap \
+        zip \
+    && docker-php-ext-enable imagick \
+    && docker-php-ext-enable redis \
+    && { \
+        echo 'memory_limit = 512M'; \
+        # See https://github.com/visiblevc/wordpress-starter/issues/160#issuecomment-544561961
+        echo 'upload_max_filesize = 50M'; \
+    } > /usr/local/etc/php/php.ini \
+    # See https://secure.php.net/manual/en/opcache.installation.php
+    && { \
+        echo 'opcache.memory_consumption = 128'; \
+        echo 'opcache.interned_strings_buffer = 8'; \
+        echo 'opcache.max_accelerated_files = 4000'; \
+        echo 'opcache.revalidate_freq = 2'; \
+        echo 'opcache.fast_shutdown = 1'; \
+        echo 'opcache.enable_cli = 1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini \
+    && sed -i 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf \
+    # Fixes issue where error is logged stating apache could not resolve the
+    # fully qualified domain name
+    && echo 'ServerName localhost' > /etc/apache2/conf-available/fqdn.conf \
+    # Grab and install wp-cli from remote
+    && curl --create-dirs \
+        -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+        -o /etc/bash_completion.d/wp-cli https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash \
+    && a2enconf fqdn \
+    && a2enmod rewrite expires
+
+# Add admin superuser, create install directory, adjust perms, & add symlink
+COPY run.sh /run.sh
+RUN useradd -ms /bin/bash -G sudo admin \
+    && echo "admin ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/admin \
+    && chmod 0440 /etc/sudoers.d/admin \
+    && chmod +x /usr/local/bin/wp /run.sh \
+    && mkdir -m 0700 /app \
+    && chown admin:admin /app \
+    && printf '%s\t%s\t%s\t%s%s%s%s%s%s%s%s\t%d\t%d\n' \
+        '/app' \
+        '/var/www/html' \
+        'fuse.bindfs' \
+            'force-user=www-data,' \
+            'force-group=www-data,' \
+            'create-for-user=admin,' \
+            'create-for-group=admin,' \
+            'create-with-perms=0644:a+X,' \
+            'chgrp-ignore,' \
+            'chown-ignore,' \
+            'chmod-ignore' \
+        0 \
+        0 > /etc/fstab
+
+USER admin
+WORKDIR /app
+EXPOSE 80 443
+CMD ["/run.sh"]

--- a/images/7.4/Dockerfile
+++ b/images/7.4/Dockerfile
@@ -1,0 +1,94 @@
+FROM php:7.4-apache
+ARG VERSION=latest
+LABEL maintainer="Derek P Sifford <dereksifford@gmail.com>" \
+      version="${VERSION}-php7.4"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install base requirements & sensible defaults + required PHP extensions
+# hadolint ignore=DL3008
+RUN echo "deb http://ftp.debian.org/debian $(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports main" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash-completion \
+        bindfs \
+        ghostscript \
+        less \
+        libjpeg-dev \
+        libmagickwand-dev \
+        libpng-dev \
+        libxml2-dev \
+        libzip-dev \
+        mariadb-client \
+        sudo \
+        unzip \
+        vim \
+        zip \
+    && apt-get -t "$(sed -n 's/^VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)-backports" install -y --no-install-recommends \
+        python-certbot-apache \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && pecl install imagick \
+    && pecl install redis \
+    && docker-php-ext-install \
+        bcmath \
+        exif \
+        gd \
+        mysqli \
+        opcache \
+        soap \
+        zip \
+    && docker-php-ext-enable imagick \
+    && docker-php-ext-enable redis \
+    && { \
+        echo 'memory_limit = 512M'; \
+        # See https://github.com/visiblevc/wordpress-starter/issues/160#issuecomment-544561961
+        echo 'upload_max_filesize = 50M'; \
+    } > /usr/local/etc/php/php.ini \
+    # See https://secure.php.net/manual/en/opcache.installation.php
+    && { \
+        echo 'opcache.memory_consumption = 128'; \
+        echo 'opcache.interned_strings_buffer = 8'; \
+        echo 'opcache.max_accelerated_files = 4000'; \
+        echo 'opcache.revalidate_freq = 2'; \
+        echo 'opcache.fast_shutdown = 1'; \
+        echo 'opcache.enable_cli = 1'; \
+    } > /usr/local/etc/php/conf.d/opcache-recommended.ini \
+    && sed -i 's/AllowOverride None/AllowOverride All/g' /etc/apache2/apache2.conf \
+    # Fixes issue where error is logged stating apache could not resolve the
+    # fully qualified domain name
+    && echo 'ServerName localhost' > /etc/apache2/conf-available/fqdn.conf \
+    # Grab and install wp-cli from remote
+    && curl --create-dirs \
+        -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+        -o /etc/bash_completion.d/wp-cli https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash \
+    && a2enconf fqdn \
+    && a2enmod rewrite expires
+
+# Add admin superuser, create install directory, adjust perms, & add symlink
+COPY run.sh /run.sh
+RUN useradd -ms /bin/bash -G sudo admin \
+    && echo "admin ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/admin \
+    && chmod 0440 /etc/sudoers.d/admin \
+    && chmod +x /usr/local/bin/wp /run.sh \
+    && mkdir -m 0700 /app \
+    && chown admin:admin /app \
+    && printf '%s\t%s\t%s\t%s%s%s%s%s%s%s%s\t%d\t%d\n' \
+        '/app' \
+        '/var/www/html' \
+        'fuse.bindfs' \
+            'force-user=www-data,' \
+            'force-group=www-data,' \
+            'create-for-user=admin,' \
+            'create-for-group=admin,' \
+            'create-with-perms=0644:a+X,' \
+            'chgrp-ignore,' \
+            'chown-ignore,' \
+            'chmod-ignore' \
+        0 \
+        0 > /etc/fstab
+
+USER admin
+WORKDIR /app
+EXPOSE 80 443
+CMD ["/run.sh"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visiblevc-wordpress",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "A slightly less shitty wordpress development workflow",
   "main": "index.js",
   "repository": "https://github.com/visiblevc/wordpress-starter.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visiblevc-wordpress",
-  "version": "0.25.1",
+  "version": "0.25.0",
   "description": "A slightly less shitty wordpress development workflow",
   "main": "index.js",
   "repository": "https://github.com/visiblevc/wordpress-starter.git",

--- a/run.sh
+++ b/run.sh
@@ -160,7 +160,7 @@ init() {
     done
 
     # If no theme dependencies or volumes exist, fall back to default
-    if [[ ${#theme_deps[@]} == 0 && -d /app/wp-content/themes && $(find /app/wp-content/themes/* -maxdepth 0 -t d | wc -l) == 0 ]]; then
+    if [[ ${#theme_deps[@]} == 0 && -d /app/wp-content/themes && $(find /app/wp-content/themes/* -maxdepth 0 -type d | wc -l) == 0 ]]; then
         theme_deps["$default_theme"]="$default_theme"
     fi
 


### PR DESCRIPTION
This PR fixes a small bug in run.sh resulting from a typo in a `find` flag.

Additionally, this PR drops support for PHP < 7.2 to [align with php](https://www.php.net/supported-versions.php)

Finally, the build script was updated to remove useless cruft and the CHANGELOG was brought up to date.