### PR TITLE
fix: bug in plugin/theme activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 0.25.1 - latest
+## 0.25.2 - latest
+
+### Patch
+
+- Fix bug in plugin/theme activation caused by attempting to activate using a URL rather than the slug in cases where plugins/themes are installed using zip URL.
+
+## 0.25.1
 
 ### Minor
 

--- a/run.sh
+++ b/run.sh
@@ -216,7 +216,7 @@ check_plugins() {
 
     for key in "${!plugin_deps[@]}"; do
         wp plugin is-installed "$key" || wp plugin install "${plugin_deps[$key]}" |& logger
-        wp plugin is-active "$key" || wp plugin activate "${plugin_deps[$key]}" |& logger
+        wp plugin is-active "$key" || wp plugin activate "$key" |& logger
     done
 }
 
@@ -225,7 +225,7 @@ check_themes() {
 
     for key in "${!theme_deps[@]}"; do
         wp theme is-installed "$key" || wp theme install "${theme_deps[$key]}" |& logger
-        wp theme is-active "$key" || wp theme activate "${theme_deps[$key]}" |& logger
+        wp theme is-active "$key" || wp theme activate "$key" |& logger
     done
 }
 


### PR DESCRIPTION
This PR fixes a small bug that occurs in cases where users have plugins/themes listed using the URL format.

the `wp plugin activate` and `wp theme activate` lines use the URL as the value rather than the key.

Should be relatively self-explanatory.

Let me know if you have any questions.

Ping @karellm