### PR TITLE
Remove duplicate phpMyAdmin service from example docs

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -44,6 +44,7 @@ services:
         environment:
             MYSQL_ROOT_PASSWORD: root
 
+    # if you want phpMyAdmin
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
         ports:
@@ -51,25 +52,6 @@ services:
 
 volumes:
     data:
-```
-
-**Need PHPMyAdmin? Add it as a service**
-
-```yml
-version: '3'
-services:
-  wordpress:
-    # same as above
-  db:
-    # same as above
-  phpmyadmin:
-    image: phpmyadmin/phpmyadmin
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-    ports:
-      - 22222:80
-volumes:
-  data:
 ```
 
 ## Running the example


### PR DESCRIPTION
The example `docker-compose.yml` in `/example/README.md` already includes phpMyAdmin. But then a separate `docker-compose.yml` example to enable phpMyAdmin is listed, which is the same except `MYSQL_ROOT_PASSWORD` is added, which is not documented in main README under "Service Environment Variables" for `phpmyadmin` and not included in [the actual](https://github.com/visiblevc/wordpress-starter/blob/master/example/docker-compose.yml) example `docker-compose.yml`.